### PR TITLE
Allow Symfony ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.0",
         "fwolfsjaeger/doctrine-cockroachdb": "^0.8",
         "doctrine/doctrine-bundle": "^2.10",
-        "symfony/dependency-injection": "^6.0|6.1|6.2|6.3"
+        "symfony/dependency-injection": "^6.0|6.1|6.2|6.3|^7.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
Thanks for this great bundle!

This PR is just to allow Symfony 7.0, which I have tested and works just fine.